### PR TITLE
Fixing empty message and button attribute

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -18,7 +18,7 @@
   <body>
     <ul id="messages"></ul>
     <form action="/" method="POST" id="chatForm">
-      <input id="txt" autocomplete="off" autofocus="on" oninput="isTyping()" placeholder="type your message here..." /><button>Send</button>
+      <input required id="txt" autocomplete="off" autofocus="on" oninput="isTyping()" placeholder="type your message here..." /><button type="submit">Send</button>
     </form>
     <script>
             var socket = io.connect('http://localhost:8080');


### PR DESCRIPTION
The attribute is set to required to prevent users from sending empty messages. 
Button for form given the attribute type="submit".